### PR TITLE
Adjust MaxTrajectory for MAC's to the current servers sync range

### DIFF
--- a/Data/Scripts/WeaponThread/M2MAC_S_Ammo.cs
+++ b/Data/Scripts/WeaponThread/M2MAC_S_Ammo.cs
@@ -15,6 +15,7 @@ using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.AreaDamageDef
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.TracerBaseDef;
+using Sandbox.ModAPI;
 namespace WeaponThread
 { // Don't edit above this line
     partial class Weapons
@@ -198,7 +199,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 4100f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -868,7 +869,7 @@ namespace WeaponThread
                 MaxLifeTime = 600, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -1193,7 +1194,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 5000f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/WeaponThread/MACL_Ammo.cs
+++ b/Data/Scripts/WeaponThread/MACL_Ammo.cs
@@ -15,6 +15,7 @@ using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.AreaDamageDef
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.TracerBaseDef;
+using Sandbox.ModAPI;
 namespace WeaponThread
 { // Don't edit above this line
     partial class Weapons
@@ -198,7 +199,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 4100f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -869,7 +870,7 @@ namespace WeaponThread
                 MaxLifeTime = 600, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -1194,7 +1195,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 5000f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/WeaponThread/MACL_S_Ammo.cs
+++ b/Data/Scripts/WeaponThread/MACL_S_Ammo.cs
@@ -15,6 +15,7 @@ using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.AreaDamageDef
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.TracerBaseDef;
+using Sandbox.ModAPI;
 namespace WeaponThread
 { // Don't edit above this line
     partial class Weapons
@@ -198,7 +199,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 4100f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -868,7 +869,7 @@ namespace WeaponThread
                 MaxLifeTime = 600, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -1193,7 +1194,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 5000f,
-                MaxTrajectory = 45000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed

--- a/Data/Scripts/WeaponThread/SMAC_Ammo.cs
+++ b/Data/Scripts/WeaponThread/SMAC_Ammo.cs
@@ -15,6 +15,7 @@ using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.AreaDamageDef
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.Texture;
 using static WeaponThread.WeaponStructure.WeaponDefinition.AmmoDef.GraphicDef.LineDef.TracerBaseDef;
+using Sandbox.ModAPI;
 namespace WeaponThread
 { // Don't edit above this line
     partial class Weapons
@@ -198,7 +199,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 5000f,
-                MaxTrajectory = 135000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -869,7 +870,7 @@ namespace WeaponThread
                 MaxLifeTime = 600, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 0f,
-                MaxTrajectory = 135000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed
@@ -1194,7 +1195,7 @@ namespace WeaponThread
                 MaxLifeTime = 0, // 0 is disabled, Measured in game ticks (6 = 100ms, 60 = 1 seconds, etc..).
                 AccelPerSec = 0f,
                 DesiredSpeed = 4100f,
-                MaxTrajectory = 135000f,
+                MaxTrajectory = (float)MyAPIGateway.Session.SessionSettings.SyncDistance,
                 FieldTime = 0, // 0 is disabled, a value causes the projectile to come to rest, spawn a field and remain for a time (Measured in game ticks, 60 = 1 second)
                 GravityMultiplier = 0f, // Gravity multiplier, influences the trajectory of the projectile, value greater than 0 to enable.
                 SpeedVariance = Random(start: 0, end: 0), // subtracts value from DesiredSpeed


### PR DESCRIPTION
This fixes the weaponcore api from returning enemy locations from beyond sync range.